### PR TITLE
add chrome support when checks the serial port connection.

### DIFF
--- a/lib/parser-v2.js
+++ b/lib/parser-v2.js
@@ -85,8 +85,8 @@ module.exports = function(serialPort){
       if(this._current) return;
       if(!this._queue.length) return;   
 
-      // if the serialport is not open yet.
-      if(!serialPort.fd){
+      // if the serialport is not open yet. Check on node && chrome.
+      if(!serialPort.fd && !serialPort.connectionId){
         var z = this;
         if(!this.boundOpen) serialPort.once('open',function(){
           z._send();


### PR DESCRIPTION
Hi, we use avrgirl-arduino in a chrome extension for the [Bitbloq](http://bitbloq.bq.com) website that uses the js-stk500. 

I think i found a problem loading to a MEGA board, and its because the serialport its open but is not detected because is checked a "fd" property, but is called "connectionId" on the browser.

I test with this change and works fine :D, but maybe you know a better way.

Thanks you so much!