### PR TITLE
update package to support serialport v5+

### DIFF
--- a/lib/parser-v2.js
+++ b/lib/parser-v2.js
@@ -85,8 +85,10 @@ module.exports = function(serialPort){
       if(this._current) return;
       if(!this._queue.length) return;   
 
+      var portIsOpen = typeof serialPort.isOpen === 'function' ? serialPort.isOpen() : serialPort.isOpen;
+
       // if the serialport is not open yet. Check on node && chrome.
-      if(!serialPort.fd && !serialPort.connectionId){
+      if(!portIsOpen){
         var z = this;
         if(!this.boundOpen) serialPort.once('open',function(){
           z._send();

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "buffer-equal": "0.0.1"
   },
   "devDependencies": {
-    "serialport": "~1.4.9",
     "intel-hex": "~0.1.1",
+    "serialport": "^6.2.0",
     "tape": "~2.12.2"
   }
 }


### PR DESCRIPTION
Hello! 👋 

In serialport v5+, the `fd` and `connectionId` properties were removed which was breaking things in avrgirl-arduino WRT flashing Arduino Mega boards. I replaced the use of these with [`isOpen`](https://github.com/node-serialport/node-serialport/commit/21a076ae6867bd3255aa62b4658d4395a2cd1ee4), which dates back to v1.5.0. `isOpen` is a function until v5+ where it was changed into a property, so I have handled that in the code somewhat gracefully.

With this change, I'll be able to upgrade avrgirl-arduino to use the latest serialport version which would be really nice to have 🙇‍♀️ 

![bitmoji](https://render.bitstrips.com/v2/cpanel/5c048d71-8ef0-4418-bbb3-2afa04a8cbbb-8016a622-e09b-4505-8856-7726a074b1f9-v1.png?transparent=1&palette=1&width=246)