### PR TITLE
update Buffer methods to modern safe ones

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 //use strict might have screwed up my this context, or might not have.. 
 
 var async = require("async");
-var bufferEqual = require('buffer-equal');
 var parser = require('./lib/parser-v2.js');
 var c = require('./lib/constants-v2.js');
 
@@ -40,7 +39,7 @@ stk500.prototype.sync = function(attempts, done) {
   var self = this;
   var tries = 1;
 
-  var cmd = new Buffer([CMD_SIGN_ON]);
+  var cmd = Buffer.from([CMD_SIGN_ON]);
 
   attempt();
   function attempt(){
@@ -133,7 +132,7 @@ stk500.prototype.verifySignature = function(signature, done) {
 
   	//console.log(reportedSignature);
   	//console.log(signature);
-  	if(!bufferEqual(signature, reportedSignature)){
+  	if(!signature.equals(reportedSignature)){
   		done(new Error("signature doesnt match. Found: " + reportedSignature.toString('hex'), error));
   	}else{
   		done();
@@ -145,7 +144,7 @@ stk500.prototype.verifySignature = function(signature, done) {
 stk500.prototype.getSignature = function(done) {
   var self = this;
 
-  var reportedSignature = new Buffer(3);
+  var reportedSignature = Buffer.alloc(3);
 
     async.series([
       function(cbdone){
@@ -154,7 +153,7 @@ stk500.prototype.getSignature = function(done) {
       	var numRx = 0x04;
       	var rxStartAddr = 0x00;
 
-  			var cmd = new Buffer([CMD_SPI_MULTI, numTx, numRx, rxStartAddr, 0x30, 0x00, 0x00, 0x00]);
+  			var cmd = Buffer.from([CMD_SPI_MULTI, numTx, numRx, rxStartAddr, 0x30, 0x00, 0x00, 0x00]);
 
   			self.parser.send(cmd, function(error, pkt) {
 
@@ -164,7 +163,7 @@ stk500.prototype.getSignature = function(done) {
   					reportedSignature.writeUInt8(sig, 0);
   				}
 
-  				// self.matchReceive(new Buffer([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
+  				// self.matchReceive(Buffer.from([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
   			  	cbdone(error);
   				// });
   			});
@@ -176,7 +175,7 @@ stk500.prototype.getSignature = function(done) {
       	var numRx = 0x04;
       	var rxStartAddr = 0x00;
 
-  			var cmd = new Buffer([CMD_SPI_MULTI, numTx, numRx, rxStartAddr, 0x30, 0x00, 0x01, 0x00]);
+  			var cmd = Buffer.from([CMD_SPI_MULTI, numTx, numRx, rxStartAddr, 0x30, 0x00, 0x01, 0x00]);
 
   			self.parser.send(cmd, function(error, pkt) {
   				//console.log("sent sig2");
@@ -187,7 +186,7 @@ stk500.prototype.getSignature = function(done) {
   					reportedSignature.writeUInt8(sig, 1);
   				}
 
-  				// self.matchReceive(new Buffer([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
+  				// self.matchReceive(Buffer.from([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
   			  	cbdone(error);
   				// });
   			});
@@ -199,7 +198,7 @@ stk500.prototype.getSignature = function(done) {
       	var numRx = 0x04;
       	var rxStartAddr = 0x00;
 
-  			var cmd = new Buffer([CMD_SPI_MULTI, numTx, numRx, rxStartAddr, 0x30, 0x00, 0x02, 0x00]);
+  			var cmd = Buffer.from([CMD_SPI_MULTI, numTx, numRx, rxStartAddr, 0x30, 0x00, 0x02, 0x00]);
 
   			self.parser.send(cmd, function(error, pkt) {
   				//console.log("sent sig3");
@@ -210,7 +209,7 @@ stk500.prototype.getSignature = function(done) {
   					reportedSignature.writeUInt8(sig, 2);
   				}
 
-  				// self.matchReceive(new Buffer([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
+  				// self.matchReceive(Buffer.from([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
   			  	cbdone(error);
   				// });
   			});
@@ -251,11 +250,11 @@ stk500.prototype.enterProgrammingMode = function(options, done) {
   var cmd3 = 0x00;
   var cmd4 = 0x00;
 
-  var cmd = new Buffer([CMD_ENTER_PROGMODE_ISP, options.timeout, options.stabDelay, options.cmdexeDelay, options.synchLoops, options.byteDelay, options.pollValue, options.pollIndex, cmd1, cmd2, cmd3, cmd4]);
+  var cmd = Buffer.from([CMD_ENTER_PROGMODE_ISP, options.timeout, options.stabDelay, options.cmdexeDelay, options.synchLoops, options.byteDelay, options.pollValue, options.pollIndex, cmd1, cmd2, cmd3, cmd4]);
 
   self.parser.send(cmd, function(error, results) {
   	//console.log("sent enter programming mode");
-  	// self.matchReceive(new Buffer([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
+  	// self.matchReceive(Buffer.from([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
     	done(error);
   	// });
   });
@@ -271,11 +270,11 @@ stk500.prototype.loadAddress = function(useaddr, done) {
   ysb = (useaddr >> 8) & 0xff;
   lsb = useaddr & 0xff;
 
-  var cmdBuf = new Buffer([CMD_LOAD_ADDRESS, msb, xsb, ysb, lsb]);
+  var cmdBuf = Buffer.from([CMD_LOAD_ADDRESS, msb, xsb, ysb, lsb]);
 
   self.parser.send(cmdBuf, function(error, results) {
   	//console.log("confirm load address");
-    // self.matchReceive(new Buffer([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
+    // self.matchReceive(Buffer.from([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
     	done(error);
     // });
 
@@ -299,14 +298,14 @@ stk500.prototype.loadPage = function(writeBytes, done) {
   var poll2 = 0x00; //Poll Value #2 (not used for flash programming)
 
 
-  var cmdBuf = new Buffer([CMD_PROGRAM_FLASH_ISP, bytesMsb, bytesLsb, mode, delay, cmd1, cmd2, cmd3, poll1, poll2]);
+  var cmdBuf = Buffer.from([CMD_PROGRAM_FLASH_ISP, bytesMsb, bytesLsb, mode, delay, cmd1, cmd2, cmd3, poll1, poll2]);
 
   cmdBuf = Buffer.concat([cmdBuf,writeBytes]);
 
   self.parser.send(cmdBuf, function(error, results) {
   	//console.log("loaded page");
 
-  	// self.matchReceive(new Buffer([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
+  	// self.matchReceive(Buffer.from([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
   		done(error);
   	// });
 
@@ -368,11 +367,11 @@ stk500.prototype.exitProgrammingMode = function(done) {
   var preDelay = 0x01;
   var postDelay = 0x01;
 
-  var cmd = new Buffer([CMD_LEAVE_PROGMODE_ISP, preDelay, postDelay]);
+  var cmd = Buffer.from([CMD_LEAVE_PROGMODE_ISP, preDelay, postDelay]);
 
   self.parser.send(cmd, function(error, results) {
   	//console.log("sent leave programming mode");
-  	// self.matchReceive(new Buffer([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
+  	// self.matchReceive(Buffer.from([Resp_STK_INSYNC, Resp_STK_OK]), timeout, function(error){
   		done(error);
   	// });
   });

--- a/lib/parser-v2.js
+++ b/lib/parser-v2.js
@@ -26,21 +26,21 @@ module.exports = function(serialPort){
         cb(e);
       });
 
-      if(!Buffer.isBuffer(body)) body = new Buffer(body);
+      if(!Buffer.isBuffer(body)) body = Buffer.from(body);
 
       var timeout = this._commandTimeout(body[0]);
 
-      var messageLen = new Buffer([0,0]);
+      var messageLen = Buffer.from([0,0]);
       messageLen.writeUInt16BE(body.length,0);    
 
       //MESSAGE_START,SEQUENCE_NUMBER,MESSAGE_SIZE,TOKEN,MESSAGE_BODY,CMD_READ/PROGRAM_FLASH/EEPROM,CHECKSUM
-      var out = Buffer.concat([new Buffer([c.MESSAGE_START,this._seq(),messageLen[0],messageLen[1],c.TOKEN]),body]);
+      var out = Buffer.concat([Buffer.from([c.MESSAGE_START,this._seq(),messageLen[0],messageLen[1],c.TOKEN]),body]);
      
  
       var checksum = this.checksum(out);
 
 
-      this._queue.push({buf:Buffer.concat([out,new Buffer([checksum])]),seq:this._inc,cb:cb,timeout:timeout});
+      this._queue.push({buf:Buffer.concat([out,Buffer.from([checksum])]),seq:this._inc,cb:cb,timeout:timeout});
 
       // if not waiting for another command to return. send this command
       this._send();
@@ -205,7 +205,7 @@ module.exports = function(serialPort){
           pkt.error.code = "E_RECV_CKSUM";
         }
 
-        pkt.message = new Buffer(pkt.message);
+        pkt.message = Buffer.from(pkt.message);
         this.emit('data',pkt);
         this.state++;// sets state to 7. the parser is not interested in any other bytes until a message is queued.
         pkt.len = pkt.message.length;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,110 @@
+{
+  "name": "stk500-v2",
+  "version": "1.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
+    "buffer-equal": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+    },
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+      "dev": true
+    },
+    "defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "intel-hex": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/intel-hex/-/intel-hex-0.1.1.tgz",
+      "integrity": "sha1-glRF26vauNeYjG39tHDfu7Gf1JQ=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "object-inspect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
+      "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w=",
+      "dev": true
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3.4"
+      }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "tape": {
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-2.12.3.tgz",
+      "integrity": "sha1-VVnVRUBQKSYnU3wBKZHsaXH2YVY=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~0.2.0",
+        "defined": "~0.0.0",
+        "glob": "~3.2.9",
+        "inherits": "~2.0.1",
+        "object-inspect": "~0.4.0",
+        "resumer": "~0.0.0",
+        "through": "~2.3.4"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "homepage": "https://github.com/Pinoccio/js-stk500",
   "dependencies": {
-    "async": "^0.9.0",
-    "buffer-equal": "0.0.1"
+    "async": "^0.9.0"
   },
   "devDependencies": {
     "intel-hex": "~0.1.1",


### PR DESCRIPTION
:wave:

This PR does it what it says on the tin. I updated all of the new Buffer() calls to the more modern and safe ones. It removes deprecation warnings in the terminal output of any project that consumes this library.

Thanks for your time! 🙇 🕙